### PR TITLE
fix typo

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -186,7 +186,7 @@
   </p><p>
     Throughout this article, we’ll be focussing on a particular neural network: InceptionV1 <d-cite key="szegedy2015going"></d-cite>
     (also known as "GoogLeNet").
-    When it came out, it was notable for <a href="http://www.image-net.org/challenges/LSVRC/2014/results#clsin">winning</a> the classification task in the 2014 ImageNet Large Scale Visual Recognition Challence <d-cite key="deng2009imagenet,russakovsky2015imagenet"></d-cite>.
+    When it came out, it was notable for <a href="http://www.image-net.org/challenges/LSVRC/2014/results#clsin">winning</a> the classification task in the 2014 ImageNet Large Scale Visual Recognition Challenge <d-cite key="deng2009imagenet,russakovsky2015imagenet"></d-cite>.
   </p>
 
   <p>


### PR DESCRIPTION
'challenge' was mispelled as 'challence' in the citation, "ImageNet Large Scale Visual Recognition Challence"